### PR TITLE
#29127 Fix: initialize for advanced search items setting

### DIFF
--- a/modules/weko-admin/weko_admin/static/js/weko_admin/search_management.js
+++ b/modules/weko-admin/weko_admin/static/js/weko_admin/search_management.js
@@ -551,6 +551,7 @@ const SPECIFIC_INDEX_VALUE = '1';
 
         var item_type_id = $("#item-type-lists").val();
 
+        $('#tr_lists0 > #item_id > #search_item').empty()
         for (labelcnt = 0; labelcnt < $scope.dataJson.detail_condition.length; labelcnt++ ) {
 
           if($scope.dataJson.detail_condition[labelcnt].item_value){


### PR DESCRIPTION
汎用詳細検索機能にて詳細検索項目がアイテムタイプを変更するたびに追加されてしまう不具合を修正しました。