### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/handle/handle/build.py
+++ b/handle/handle/build.py
@@ -27,8 +27,8 @@ config = {
     'SERVER_ADMINS': ' '.join(['"%s"'%s for s in os.getenv('SERVER_ADMINS', "").split(" ")]),
     'REPLICATION_ADMINS': ' '.join(['"%s"'%s for s in os.getenv('REPLICATION_ADMINS', "").split(" ")]),
     'HANDLE_HOST_IP': os.getenv('HANDLE_HOST_IP', '0.0.0.0'),
-    'SERVER_PRIVATE_KEY_PEM': os.getenv('SERVER_PRIVATE_KEY_PEM', '').encode('ASCII'), # Explict convert to byte string
-    'SERVER_PUBLIC_KEY_PEM': os.getenv('SERVER_PUBLIC_KEY_PEM', '').encode('ASCII'), # Explict convert to byte string
+    'SERVER_PRIVATE_KEY_PEM': os.getenv('SERVER_PRIVATE_KEY_PEM', '').encode('ASCII'), # Explicit convert to byte string
+    'SERVER_PUBLIC_KEY_PEM': os.getenv('SERVER_PUBLIC_KEY_PEM', '').encode('ASCII'), # Explicit convert to byte string
     'STORAGE_TYPE': os.getenv('STORAGE_TYPE', ''),
     'SQL_URL': os.getenv('SQL_URL', ''),
     'SQL_DRIVER': os.getenv('SQL_DRIVER', 'com.mysql.jdbc.Driver'),
@@ -41,8 +41,8 @@ config = {
     'DESC': os.getenv('DESC', 'YOUR DESCRIPTION'),
     'CONTACT_EMAIL': os.getenv('CONTACT_EMAIL', 'YOUR EMAIL'),
     'ORG_NAME': os.getenv('ORG_NAME', 'YOUR ORG'),
-    'ADMIN_PRIVATE_KEY_PEM': os.getenv('SERVER_PRIVATE_KEY_PEM', '').encode('ASCII'), # Explict convert to byte string
-    'ADMIN_PUBLIC_KEY_PEM': os.getenv('SERVER_PUBLIC_KEY_PEM', '').encode('ASCII') # Explict convert to byte string
+    'ADMIN_PRIVATE_KEY_PEM': os.getenv('SERVER_PRIVATE_KEY_PEM', '').encode('ASCII'), # Explicit convert to byte string
+    'ADMIN_PUBLIC_KEY_PEM': os.getenv('SERVER_PUBLIC_KEY_PEM', '').encode('ASCII') # Explicit convert to byte string
 }
 
 # Create private / public keys based on config using hdl-convert-key tool

--- a/scripts/demo/properties/other_language.py
+++ b/scripts/demo/properties/other_language.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-"""Definition of 2rd language property."""
+"""Definition of 2nd language property."""
 from .property_func import get_property_schema, get_property_form, set_post_data
 from . import property_config as config
 

--- a/scripts/demo/update_item_type.py
+++ b/scripts/demo/update_item_type.py
@@ -330,12 +330,12 @@ def main():
                     db.session.commit()
                     print(
                         datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
-                        'Update propery {}({}) to db is success.'.format(prop.name, prop.id))
+                        'Update property {}({}) to db is success.'.format(prop.name, prop.id))
                 except Exception as e:
                     db.session.rollback()
                     print(
                         datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
-                        'Update propery {}({}) to db is fail.'.format(prop.name, prop.id),
+                        'Update property {}({}) to db is fail.'.format(prop.name, prop.id),
                         e)
         except Exception as ex:
             print(

--- a/scripts/demo/update_itemtype_full.py
+++ b/scripts/demo/update_itemtype_full.py
@@ -118,7 +118,7 @@ def main():
                         _render["table_row"].append(_prop_id)
                         if _prop_id in _mapping.mapping and _mapping.mapping[_prop_id] and "=" not in _mapping.mapping[_prop_id]:
                             _mapping.mapping[_prop_id] = pickle.loads(pickle.dumps(_render["table_row_map"]["mapping"][_prop_id],-1))
-                        print("property cus_{} has been registerd.".format(id))
+                        print("property cus_{} has been registered.".format(id))
 
                 if len(cur_prop_ids) > 0:
                     from weko_itemtypes_ui.utils import (
@@ -155,7 +155,7 @@ def main():
         db.session.commit()
         
         
-        print("session commited.")
+        print("session committed.")
     except Exception as e:
         print(traceback.format_exc())
         db.session.rollback()

--- a/scripts/demo/update_itemtype_multiple.py
+++ b/scripts/demo/update_itemtype_multiple.py
@@ -136,7 +136,7 @@ def main():
                     _render["table_row"].append(_prop_id)
                     if _prop_id in _mapping.mapping and _mapping.mapping[_prop_id] and "=" not in _mapping.mapping[_prop_id]:
                         _mapping.mapping[_prop_id] = pickle.loads(pickle.dumps(_render["table_row_map"]["mapping"][_prop_id],-1))
-                    current_app.logger.info("property cus_{} has been registerd.".format(id))
+                    current_app.logger.info("property cus_{} has been registered.".format(id))
 
             if len(cur_prop_ids) > 0:
                 from weko_itemtypes_ui.utils import (
@@ -177,7 +177,7 @@ def main():
                 current_app.logger.info(f"[FIX] item_type:{itemType.id}")
                 for mid in fixed_mapping_ids:
                     current_app.logger.info(f"[FIX] item_type_mapping:{mid}")
-        current_app.logger.info("session commited.")
+        current_app.logger.info("session committed.")
     except Exception as e:
         current_app.logger.error(traceback.format_exc())
         db.session.rollback()

--- a/scripts/translations/update-msg.py
+++ b/scripts/translations/update-msg.py
@@ -167,7 +167,7 @@ def print_result(result, weko_path):
                          'ERROR', 'MESSAGE (C)', 'DATA'])
         writer.writerows(output_err_data_to_file)
     print('')
-    print('All error informations in {}/replace_msg_error.csv'.format(weko_path))
+    print('All error information in {}/replace_msg_error.csv'.format(weko_path))
 
 
 if __name__ == "__main__":

--- a/test/tavern/helper/request_helper.py
+++ b/test/tavern/helper/request_helper.py
@@ -203,7 +203,7 @@ def request_create_action_param(action_version, link_data = None, identifier = N
             identifier_grant_ndl_jalc_doi_link (str): identifier grant ndl jalc doi link
             identifier_grant_ndl_jalc_doi_suffix (str): identifier grant ndl jalc doi suffix
             community (str): community id
-            commond (str): commond
+            command (str): command
             temporary_save (int): temporary save
     """
     return_params = {

--- a/tools/deleteItem.py
+++ b/tools/deleteItem.py
@@ -33,7 +33,7 @@ def deleteItem(id):
         if i.pid_type == 'recid':
             itemid_list.append(i.pid_value)
 
-    """ remvoe duplicated uuid """
+    """ remove duplicated uuid """
     object_uuid_list = list(set(object_uuid_list))
     itemid_list = list(set(itemid_list))
 

--- a/tools/oaisetutil.py
+++ b/tools/oaisetutil.py
@@ -123,7 +123,7 @@ def _addOAISet(id):
                 list(traceback.TracebackException.from_exception(sqlerror).format()))
             db.session.rollback()
         current_app.logger.debug(
-            "comunity: {0}, count: {1}".format(c.id, count))
+            "community: {0}, count: {1}".format(c.id, count))
 
 
 def addOAISetToAll():


### PR DESCRIPTION
Fix typos discovered in Python files by codespell - https://pypi.org/project/codespell

% `codespell ﻿﻿--ignore-words-list=caf,countrys,fo,fro,misstype,nam,nd,sme,som,te,tha,vie,vor --skip="modules/*" **/*.py`
```
```
% `codespell -ignore-words-list=caf,countrys,fo,fro,misstype,nam,nd,sme,som,te,tha,vie,vor --skip="modules/*" --write-changes **/*.py ` 